### PR TITLE
Fixed requesting source if script not found

### DIFF
--- a/Run.GSEA.R
+++ b/Run.GSEA.R
@@ -4,7 +4,6 @@
 library("utils")
 cat("\n")
 gseasource <- list.files(getwd(),pattern="GSEA.1.0.R", full.names=T, recursive=FALSE)[1]
-cat(gseasource)
 if (!is.na(gseasource)) {
 	GSEA.program.location <- gseasource
 } else {

--- a/Run.GSEA.R
+++ b/Run.GSEA.R
@@ -4,10 +4,11 @@
 library("utils")
 cat("\n")
 gseasource <- list.files(getwd(),pattern="GSEA.1.0.R", full.names=T, recursive=FALSE)[1]
-if((gseasource != "NA") == "TRUE"){
-GSEA.program.location <- gseasource
-	} else {
-		GSEA.program.location <- readline(prompt = ("Input path to GSEA.1.0.R Source (or drop file into R window): "))   #  R source program (change pathname to the rigth location in local machine)
+cat(gseasource)
+if (!is.na(gseasource)) {
+	GSEA.program.location <- gseasource
+} else {
+	GSEA.program.location <- readline(prompt = ("Input path to GSEA.1.0.R Source (or drop file into R window): "))   #  R source program (change pathname to the rigth location in local machine)
 }
 source(GSEA.program.location, verbose=T, max.deparse.length=9999)
 cat("\n")


### PR DESCRIPTION
This fixes an `NA` checking bug that came up if the run script couldn't find the R_GSEA source script. 